### PR TITLE
Fixing playtime counter only keeping track of minutes, not hours

### DIFF
--- a/Spectabis-WPF/Domain/Playtime.cs
+++ b/Spectabis-WPF/Domain/Playtime.cs
@@ -53,7 +53,7 @@ namespace Spectabis_WPF.Domain
             IniFile spectabis = new IniFile(BaseDirectory + @"\resources\configs\" + game + @"\spectabis.ini");
 
             //Save Timespan in minutes
-            spectabis.Write("playtime",$"{time.Minutes.ToString()}","Spectabis");
+            spectabis.Write("playtime",$"{time.TotalMinutes.ToString()}","Spectabis");
 
             Console.WriteLine($"Readtime: {ReadTime}, NewTime: {time}, WriteExists: {File.Exists(BaseDirectory + @"\resources\configs\" + game + @"\spectabis.ini")}");
 

--- a/Spectabis-WPF/Views/MainWindow.xaml.cs
+++ b/Spectabis-WPF/Views/MainWindow.xaml.cs
@@ -926,7 +926,7 @@ namespace Spectabis_WPF.Views
                 {
                     SessionPlaytime.Stop();
                     updatePlaytimeUI.Stop();
-                    Console.WriteLine("Session Lenght: " + SessionPlaytime.Elapsed.Minutes);
+                    Console.WriteLine("Session Lenght: " + SessionPlaytime.Elapsed.TotalMinutes);
                     Console.WriteLine($"SessionTimer Working: {SessionPlaytime.IsRunning}");
                 }
             }
@@ -935,19 +935,19 @@ namespace Spectabis_WPF.Views
         //Update session timer in UI
         private void updatePlaytimeUI_Tick(object sender, EventArgs e)
         {
-            if(SessionPlaytime.Elapsed.Minutes == 1)
+            if(SessionPlaytime.Elapsed.TotalMinutes == 1)
             {
-                this.Invoke(new Action(() => SessionLenght.Text = $"Current Session: {SessionPlaytime.Elapsed.Minutes} minute"));
+                this.Invoke(new Action(() => SessionLenght.Text = $"Current Session: {SessionPlaytime.Elapsed.TotalMinutes} minute"));
             }
             else
             {
-                this.Invoke(new Action(() => SessionLenght.Text = $"Current Session: {SessionPlaytime.Elapsed.Minutes} minutes"));
+                this.Invoke(new Action(() => SessionLenght.Text = $"Current Session: {SessionPlaytime.Elapsed.TotalMinutes} minutes"));
             }
 
             //As this timer updates every minute, playtime in file gets updated also
             Playtime.AddPlaytime(CurrentGame, TimeSpan.FromMinutes(1));
 
-            Console.WriteLine($"Updating UI with TimerTimer: {SessionPlaytime.Elapsed} minutes, adding 1 minute to file");
+            Console.WriteLine($"Updating UI with TimerTimer: {SessionPlaytime.Elapsed.TotalMinutes} minutes, adding 1 minute to file");
         }
 
 


### PR DESCRIPTION
#36 
Playtime is only keeping track of the minute-part. Fixed code to keep track of hour part as well, in minute format.