### PR TITLE
Spectabis-gui: Remove old mipmap hack option

### DIFF
--- a/Spectabis-WPF/Views/MainWindow.xaml
+++ b/Spectabis-WPF/Views/MainWindow.xaml
@@ -97,7 +97,6 @@
                             <CheckBox x:Name="fullboot" ToolTip="Show classical PS2 startup" Style="{StaticResource LargerCheckbox}">Display BIOS when booting</CheckBox>
                             <CheckBox x:Name="nohacks" ToolTip="Disable all speedhacks in emulator" Style="{StaticResource LargerCheckbox}">Disable Speedhacks</CheckBox>
                             <CheckBox x:Name="widescreen" ToolTip="Use patches to play games in widescreen resolutions" Style="{StaticResource LargerCheckbox}">Widescreen Patches</CheckBox>
-                            <CheckBox x:Name="hwmipmap" ToolTip="Only in latest PCSX2 Developer Versions" Style="{StaticResource LargerCheckbox}">Enable Hardware Mipmap Hack</CheckBox>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Width="301">
                             <StackPanel Orientation="Horizontal">

--- a/Spectabis-WPF/Views/MainWindow.xaml.cs
+++ b/Spectabis-WPF/Views/MainWindow.xaml.cs
@@ -310,12 +310,10 @@ namespace Spectabis_WPF.Views
                 //Sets the values from PCSX2_vm ini
                 if (_widescreen == "enabled") { widescreen.IsChecked = true; } else { widescreen.IsChecked = false; }
 
-                //GDSX file mipmap hack
+                //GSdx ini settings
                 var gsdxIni = new IniFile(_cfgDir + @"\GSdx.ini");
-                var _mipmaphack = gsdxIni.Read("UserHacks_mipmap", "Settings");
                 var _shaderfx = gsdxIni.Read("shaderfx", "Settings");
 
-                if (_mipmaphack == "1") { hwmipmap.IsChecked = true; } else { hwmipmap.IsChecked = false; }
                 if (_shaderfx == "1") { Shader_Checkbox.IsChecked = true; Shader_Button.IsEnabled = true; } else { Shader_Checkbox.IsChecked = false; Shader_Button.IsEnabled = false; }
 
 
@@ -536,17 +534,6 @@ namespace Spectabis_WPF.Views
             else
             {
                 vmIni.Write("EnableWideScreenPatches", "disabled", "EmuCore");
-            }
-
-            //Mipmap hack - written to gsdx.ini
-            if (hwmipmap.IsChecked == true)
-            {
-                gsdxIni.Write("UserHacks_mipmap", "1", "Settings");
-                gsdxIni.Write("UserHacks", "1", "Settings");
-            }
-            else
-            {
-                gsdxIni.Write("UserHacks_mipmap", "0", "Settings");
             }
 
             //Shader status - written to gsdx.ini


### PR DESCRIPTION
The feature is replaced by a gui option in GSdx and is mostly automatic anyway.

Note: I didn't test this pr as I haven't yet setup spectabis to compile on my end and appveyor is also complaining about missing assemblies.